### PR TITLE
Fix infinite looping bug

### DIFF
--- a/nlp/wordnet/wordnet.go
+++ b/nlp/wordnet/wordnet.go
@@ -216,7 +216,9 @@ func (wn *WordNet) hypernyms(ss *Synset) map[*Synset]int {
 			result[s] = level
 			for _, ptr := range s.Pointer {
 				if ptr.Symbol[:1] == Hypernym {
-					newNext[wn.Synset[ptr.Synset]] = struct{}{}
+					if _, ok := result[wn.Synset[ptr.Synset]]; !ok {
+						newNext[wn.Synset[ptr.Synset]] = struct{}{}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
In the hypernyms function, if two words have each other as hypernyms, the code loops forever (for example, the words 'inhibit' and 'restrict'). This adds a check to see if the current synset has already been seen, only adding it to newNext if it is new.